### PR TITLE
Change delete from favorites with redirect_back

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -21,10 +21,11 @@ class FavoritesController < ApplicationController
     flash[:notice] = "#{pet.name} has been added to your favorites!"
   end
 
+# 
   def destroy
     pet = Pet.find(params[:pet_id])
     favorites.delete_pet(pet.id)
-    redirect_to "/pets/#{params[:pet_id]}"
+    redirect_back(fallback_location: '/favorites')
     flash[:notice] = "#{pet.name} has been removed from your favorites."
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -21,7 +21,8 @@ class FavoritesController < ApplicationController
     flash[:notice] = "#{pet.name} has been added to your favorites!"
   end
 
-# 
+# redirect_back to just use one method and stay RESTful
+# chose '/favorites' as fallback_location for user experience
   def destroy
     pet = Pet.find(params[:pet_id])
     favorites.delete_pet(pet.id)

--- a/app/models/favorites.rb
+++ b/app/models/favorites.rb
@@ -7,15 +7,15 @@ class Favorites
   end
 
   def add_pet(id)
-    @contents[id.to_s] = 1
+    contents[id.to_s] = 1
   end
 
   def total_count
-    @contents.values.sum
+    contents.values.sum
   end
 
   def delete_pet(id)
-    @contents.delete(id.to_s)
+    contents.delete(id.to_s)
   end
 
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -4,7 +4,7 @@
     <section id = "favorite-<%= pet.id %>">
       <%= image_tag pet.image %>
       <%= pet.name %>
-      <%= button_to "Remove #{pet.name} from Favorites" %>
+      <%= button_to "Remove #{pet.name} from Favorites", "/favorites/#{pet.id}", method: :delete %>
     </section>
   <% end %>
 

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -4,6 +4,7 @@
     <section id = "favorite-<%= pet.id %>">
       <%= image_tag pet.image %>
       <%= pet.name %>
+      <%= button_to "Remove #{pet.name} from Favorites" %>
     </section>
   <% end %>
 

--- a/spec/features/favorites/destroy_spec.rb
+++ b/spec/features/favorites/destroy_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "a user can remove individual pets from favorites" do
 
     visit '/favorites'
 
-    within "favorite-#{pet_1.id}" do
+    within "#favorite-#{pet_1.id}" do
       click_button "Remove #{pet_1.name} from Favorites"
     end
 

--- a/spec/features/favorites/destroy_spec.rb
+++ b/spec/features/favorites/destroy_spec.rb
@@ -62,4 +62,25 @@ RSpec.describe "a user can remove individual pets from favorites" do
       expect(page).to have_content("Favorites: 0")
     end
   end
+
+  it "can remove pet from favorites on favorites page" do
+    pet_1 = create(:random_pet)
+
+    visit "/pets/#{pet_1.id}"
+    click_button "Add #{pet_1.name} to Favorites"
+
+    visit '/favorites'
+
+    within "favorite-#{pet_1.id}" do
+      click_button "Remove #{pet_1.name} from Favorites"
+    end
+
+    expect(current_path).to eq('/favorites')
+    expect(page).not_to have_content(pet_1.name)
+    expect(page).not_to have_css("img[src = '#{pet_1.image}']")
+    within ".topnav" do
+      expect(page).to have_content("Favorites: 0")
+    end
+
+  end
 end


### PR DESCRIPTION
## What functionality does this accomplish?

-Able to delete pets from favorites from favorites page
-Able to redirect to both pet show page and favorites index page through one delete method

closes #9 

**Description:**

## What did you struggle on to complete?
Learning about redirect_back

## Current Test Suite:
### Test Coverage Percentage: 100%
- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
- [x] New Tests added for new features

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
* Resource link AND small description of info gathered/learned
redirect_back

## Review Requests(optional):
n/a

## Please include a gif of how you feel about this branch:
![tenor](https://user-images.githubusercontent.com/51763489/70365143-2fb28b00-184d-11ea-860b-537b90dbe726.gif)

